### PR TITLE
feat: make upload story book preview folder based on repo

### DIFF
--- a/.github/workflows/verify_library.yml
+++ b/.github/workflows/verify_library.yml
@@ -179,10 +179,11 @@ jobs:
         if: inputs.ENABLE_VISUAL_TESTING
         env:
           PR_NUM: ${{ github.event.pull_request.number }}
+          REPO_NAME: ${{ github.event.repository.name }}
         run: |
           ls $GITHUB_WORKSPACE/docs-dist || echo "docs-dist is currently empty"
           bucket=side-plat-tools-public
-          folderPath=storybook-previews/pantry/$PR_NUM
+          folderPath=storybook-previews/$REPO_NAME/$PR_NUM
           echo "Uploading storybook preview to Cloud Storage path \"$bucket/$folderPath\""
           gsutil -m cp -r $GITHUB_WORKSPACE/docs-dist/** gs://$bucket/$folderPath
           echo ""


### PR DESCRIPTION
@scott-sideinc I am hoping to set up storybook previews on PRs in https://github.com/reside-eng/payment-statement-components just like Pantry. Will this approach be OK? Looks like `repository.name` will resolve with org so the folder path will be `storybook-previews/reside-eng/payment-statement-components/$PR_NUM`. Same for Pantry after this change. 