### PR TITLE
fix: lerna publish

### DIFF
--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -68,6 +68,7 @@ on:
 
 env:
   NODE_VERSION: ${{ inputs.NODE_VERSION }}
+  LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch '*'
 
 jobs:
   release:
@@ -180,20 +181,18 @@ jobs:
       - name: Publish to @latest dist-tag
         if: github.ref == 'refs/heads/main' && inputs.IS_MONOREPO
         run: |
-          echo lerna publish ${LERNA_DEFAULT_ARGS} --conventional-graduate
-          yarn lerna publish ${LERNA_DEFAULT_ARGS} --conventional-graduate
+          echo lerna publish ${{ env.LERNA_DEFAULT_ARGS }} --conventional-graduate
+          yarn lerna publish ${{ env.LERNA_DEFAULT_ARGS }} --conventional-graduate
         env:
           GH_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch \'*\'
 
       - name: Publish to a prerelease dist-tag
         if: github.ref != 'refs/heads/main' && inputs.IS_MONOREPO
         run: |
-          echo lerna publish $LERNA_DEFAULT_ARGS --conventional-prerelease --dist-tag ${GITHUB_REF##*/} --preid ${GITHUB_REF##*/}
-          yarn lerna publish $LERNA_DEFAULT_ARGS --conventional-prerelease --dist-tag ${GITHUB_REF##*/} --preid ${GITHUB_REF##*/}
+          echo lerna publish ${{ env.LERNA_DEFAULT_ARGS }} --conventional-prerelease --dist-tag ${GITHUB_REF##*/} --preid ${GITHUB_REF##*/}
+          yarn lerna publish ${{ env.LERNA_DEFAULT_ARGS }} --conventional-prerelease --dist-tag ${GITHUB_REF##*/} --preid ${GITHUB_REF##*/}
         env:
           GH_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch '*'
 
   notification:
     if: always() && inputs.ENABLE_SLACK_NOTIFICATION

--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -108,7 +108,7 @@ jobs:
       - name: Test
         if: inputs.ENABLE_TESTING && inputs.ENABLE_COVERAGE
         run: yarn test:cov
-        
+
       - name: Upload coverage to Coveralls
         if: inputs.ENABLE_TESTING && inputs.ENABLE_COVERAGE
         uses: coverallsapp/github-action@v2.2.0
@@ -184,7 +184,7 @@ jobs:
           yarn lerna publish $LERNA_DEFAULT_ARGS --conventional-graduate
         env:
           GH_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch "*"
+          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch '*'
 
       - name: Publish to a prerelease dist-tag
         if: github.ref != 'refs/heads/main' && inputs.IS_MONOREPO
@@ -193,7 +193,7 @@ jobs:
           yarn lerna publish $LERNA_DEFAULT_ARGS --conventional-prerelease --dist-tag ${GITHUB_REF##*/} --preid ${GITHUB_REF##*/}
         env:
           GH_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
-          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch "*"
+          LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch '*'
 
   notification:
     if: always() && inputs.ENABLE_SLACK_NOTIFICATION

--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -180,8 +180,8 @@ jobs:
       - name: Publish to @latest dist-tag
         if: github.ref == 'refs/heads/main' && inputs.IS_MONOREPO
         run: |
-          echo lerna publish $LERNA_DEFAULT_ARGS --conventional-graduate
-          yarn lerna publish $LERNA_DEFAULT_ARGS --conventional-graduate
+          echo lerna publish ${LERNA_DEFAULT_ARGS} --conventional-graduate
+          yarn lerna publish ${LERNA_DEFAULT_ARGS} --conventional-graduate
         env:
           GH_TOKEN: ${{ steps.get-workflow-token.outputs.token }}
           LERNA_DEFAULT_ARGS: --exact --concurrency 1 --yes --conventional-commits --create-release github --allow-branch '*'


### PR DESCRIPTION
## Downstream PRs

- Previously failed CI: https://github.com/reside-eng/test-monorepo/actions/runs/8149957829/job/22275427419
- Fixed CI with this change: https://github.com/reside-eng/test-monorepo/actions/runs/8150160274/job/22275963387

## Changes

With the upgrade of Lerna JS to v8, it appears some internal lib updates started failing interpretation on how Github Actions was providing the `--allow-branch` string value. This change seems to evaluate the value where the lib works as expected. 

I've also moved the env variable up to the top since it's shared across two jobs.

