### PR TITLE
fix: use side extended config to avoid ratelimit issue

### DIFF
--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -142,6 +142,7 @@ jobs:
         uses: cycjimmy/semantic-release-action@v3
         id: semantic
         with:
+          # NOTE: ^19 is ESM and was causing a break
           semantic_version: ^18
           branches: |
             [
@@ -152,6 +153,10 @@ jobs:
               {name: 'beta', prerelease: true},
               {name: 'alpha', prerelease: true}
             ]
+          # Config override used disable features of @semantic-release/github causing rate limit
+          # @semantic-release/exec is installed internally
+          extends: |
+            @side/semantic-config-base
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
### Description
**Release CI workflow failed due to raitelimit:** https://github.com/reside-eng/pantry-test/actions/runs/8654877126/job/23732890802#step:14:1095

**Test SM using extended config without hitting rate limit issue:** https://github.com/reside-eng/pantry-test/actions/runs/8655116689/job/23733549521#step:14:1085
