### PR TITLE
fix: correctly load Inter font in playwright action

### DIFF
--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -20,13 +20,13 @@ runs:
       # so the file was downloaded and uploaded to side-plat-tools-public bucket
       run: |
         wget -O Inter.zip https://storage.googleapis.com/side-plat-tools-public/playwright-fonts/Inter.zip
-        echo "Inter Zip file downloaded, unzipping"
+        echo "::debug::Inter Zip file downloaded, unzipping"
         unzip -d Inter/ Inter.zip
-        echo "Inter font file unzipped, moving"
+        echo "::debug::Inter font file unzipped, moving"
         mv Inter /usr/share/fonts/
-        echo "Inter font file moved, building to cache"
+        echo "::debug::Inter font file moved, building to cache"
         fc-cache -fv
-        echo "Inter font built to cache"
+        echo "::debug::Inter font built to cache"
       shell: bash
 
     - name: Run integration tests

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -16,13 +16,14 @@ runs:
       shell: bash
 
     - name: Install Google Fonts
+      # NOTE: Invalid zip file was being downloaded through wget -O Inter.zip https://fonts.google.com/download?family=Inter
+      # so the file was downloaded and uploaded to side-plat-tools-public bucket
       run: |
-        echo "Downloading Inter font zip file"
-        wget -O $GITHUB_WORKSPACE/Inter.zip https://fonts.google.com/download?family=Inter
+        wget -O Inter.zip https://storage.googleapis.com/side-plat-tools-public/playwright-fonts/Inter.zip
         echo "Inter Zip file downloaded, unzipping"
-        unzip -d $GITHUB_WORKSPACE/Inter/ $GITHUB_WORKSPACE/Inter.zip
+        unzip -d Inter/ Inter.zip
         echo "Inter font file unzipped, moving"
-        mv $GITHUB_WORKSPACE/Inter /usr/share/fonts/
+        mv Inter /usr/share/fonts/
         echo "Inter font file moved, building to cache"
         fc-cache -fv
         echo "Inter font built to cache"

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -17,11 +17,12 @@ runs:
 
     - name: Install Google Fonts
       run: |
-        wget -O Inter.zip https://fonts.google.com/download?family=Inter
+        echo "Downloading Inter font zip file"
+        wget -O $GITHUB_WORKSPACE/Inter.zip https://fonts.google.com/download?family=Inter
         echo "Inter Zip file downloaded, unzipping"
-        unzip -d Inter/ Inter.zip
+        unzip -d $GITHUB_WORKSPACE/Inter/ $GITHUB_WORKSPACE/Inter.zip
         echo "Inter font file unzipped, moving"
-        mv Inter /usr/share/fonts/
+        mv $GITHUB_WORKSPACE/Inter /usr/share/fonts/
         echo "Inter font file moved, building to cache"
         fc-cache -fv
         echo "Inter font built to cache"

--- a/.github/actions/playwright/action.yml
+++ b/.github/actions/playwright/action.yml
@@ -18,9 +18,13 @@ runs:
     - name: Install Google Fonts
       run: |
         wget -O Inter.zip https://fonts.google.com/download?family=Inter
+        echo "Inter Zip file downloaded, unzipping"
         unzip -d Inter/ Inter.zip
+        echo "Inter font file unzipped, moving"
         mv Inter /usr/share/fonts/
+        echo "Inter font file moved, building to cache"
         fc-cache -fv
+        echo "Inter font built to cache"
       shell: bash
 
     - name: Run integration tests

--- a/.github/workflows/verify_library.yml
+++ b/.github/workflows/verify_library.yml
@@ -188,7 +188,7 @@ jobs:
 
       - name: Comment preview links
         if: inputs.ENABLE_VISUAL_TESTING || inputs.ENABLE_PLAYWRIGHT
-        uses: reside-eng/workflow-templates-library/.github/actions/previews-comment@v1
+        uses: reside-eng/workflow-templates-library/.github/actions/previews-comment@playright-font-issue
         with:
           storybook-preview-url: ${{ steps.storybook.outputs.preview-url }}
           playwright-preview-url: ${{ steps.playwright.outputs.preview-url }}

--- a/.github/workflows/verify_library.yml
+++ b/.github/workflows/verify_library.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run Playwright integration tests and upload preview
         if: inputs.ENABLE_PLAYWRIGHT
-        uses: reside-eng/workflow-templates-library/.github/actions/playwright@v1
+        uses: reside-eng/workflow-templates-library/.github/actions/playwright@playright-font-issue
         id: playwright
         with:
           service-account: ${{ secrets.CI_SERVICE_ACCOUNT }}

--- a/.github/workflows/verify_library.yml
+++ b/.github/workflows/verify_library.yml
@@ -174,7 +174,7 @@ jobs:
 
       - name: Run Playwright integration tests and upload preview
         if: inputs.ENABLE_PLAYWRIGHT
-        uses: reside-eng/workflow-templates-library/.github/actions/playwright@playright-font-issue
+        uses: reside-eng/workflow-templates-library/.github/actions/playwright@v1
         id: playwright
         with:
           service-account: ${{ secrets.CI_SERVICE_ACCOUNT }}
@@ -188,7 +188,7 @@ jobs:
 
       - name: Comment preview links
         if: inputs.ENABLE_VISUAL_TESTING || inputs.ENABLE_PLAYWRIGHT
-        uses: reside-eng/workflow-templates-library/.github/actions/previews-comment@playright-font-issue
+        uses: reside-eng/workflow-templates-library/.github/actions/previews-comment@v1
         with:
           storybook-preview-url: ${{ steps.storybook.outputs.preview-url }}
           playwright-preview-url: ${{ steps.playwright.outputs.preview-url }}


### PR DESCRIPTION
:tickets: TICKET-000 <!-- Please set the ticket ID -->

<!--
## Helpful Reminders

Did you add TODO or FIXME comments?
* Create Jira tickets and add the ticket IDs to your comments

Would this code benefit from tests?
* Add tests where applicable
* Tests added using `it.todo` will be tech debt; Please create
  tickets for these (or include the tests in this PR 😄)

Did you add or modify package.json scripts?
* Update the "Local Development > Commands" section in the README

Did you add a new library?
* Consider linking to its documentation in the README
* If the library is non-trivial, consider adding a documentation
  section in the README

Did you add or modify environment variables?
* Update the "Environment Variables" section of the README

-->

## Upstream PRs

<!-- If this PR depends on other PRs, please add a bullet point list here -->

## Downstream PRs
https://github.com/reside-eng/payment-statement-components/pull/590
<!-- If this PR is depended on by other PRs, please add a bullet point list here -->

## Changes
At some point `wget` from google fonts URL stopped downloading a valid Zip file so the playwright action has been failing ([as seen here](https://github.com/reside-eng/payment-statement-components/actions/runs/9420819436/job/25953660949?pr=589#step:17:119)) - this change points to downloading the valid Inter.zip file from side-plat-tools-public bucket

Debug logs were also added for easier debugging in the future
<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->

## Notes for Reviewers
This has been blocking builds in payment-statement-components for many months now (seems to be since jan from looking at failed verifies, but logs don't go back that far)
<!--
Add info that reviewers may need to know:

* Steps to try out new changes
* Known errors
* Related tasks
* Etc.

-->

## Recordings/Screenshots

<!-- If this PR affects the UI, consider adding screenshots or recordings  -->
![image](https://github.com/reside-eng/workflow-templates-library/assets/2992224/c428bd81-5d74-4ae5-9b69-cebecddd63de)
