### PR TITLE
feat: replace `config set` commands with env vars

### DIFF
--- a/.github/workflows/release_library.yml
+++ b/.github/workflows/release_library.yml
@@ -88,17 +88,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
 
-      - name: Configure NPM auth token
-        run: |
-          yarn config set npmAuthToken ${{ secrets.NPM_PUBLISH_TOKEN }}
-
-      - name: Configure Package Manager
-        run: |
-          echo Configuring NPM_TOKEN globally for .npmrc
-          npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_PUBLISH_TOKEN }}
-          npm whoami
-
       - name: Install dependencies with Yarn-Berry
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
         run: |
           yarn install --immutable
 

--- a/.github/workflows/verify_library.yml
+++ b/.github/workflows/verify_library.yml
@@ -101,17 +101,9 @@ jobs:
           node-version: ${{ env.NODE_VERSION }}
           cache: 'yarn'
 
-      - name: Configure NPM auth token
-        run: |
-          yarn config set npmAuthToken ${{ secrets.NPM_READ_TOKEN }}
-
-      - name: Configure Package Manager
-        run: |
-          echo Configuring NPM_TOKEN globally for .npmrc
-          npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_READ_TOKEN }}
-          npm whoami
-
       - name: Install dependencies with Yarn-Berry
+        env:
+          YARN_NPM_AUTH_TOKEN: ${{ secrets.NPM_READ_TOKEN }}
         run: yarn install --immutable
 
       - name: Verify lint


### PR DESCRIPTION
## Changes

Replaced commands that modify local NPM/Yarn config files with environment variables that achieve the same effect.

### Test PRs

- https://github.com/reside-eng/test-library-ci/pull/4
- https://github.com/reside-eng/pantry/pull/2092

## Notes for Reviewers

This change prevents the need to clean up dirty `.npmrc` or `.yarnrc.yml` files since they don't need to be modified.

> [!WARNING]
> I left the `publish.yml` workflow alone since it appears we need to configure auth for separate registries at the same time (both NPM and Github Packages). 