### PR TITLE
fix: use correct node version in check deps workflow

### DIFF
--- a/.github/workflows/check-nodejs-dependencies.yml
+++ b/.github/workflows/check-nodejs-dependencies.yml
@@ -38,6 +38,9 @@ on:
       NPM_READ_TOKEN:
         required: true
 
+env:
+  NODE_VERSION: ${{ inputs.NODE_VERSION }}
+
 jobs:
   check-dependencies:
     name: ${{ inputs.WORKFLOW_NAME }}

--- a/.github/workflows/check-nodejs-dependencies.yml
+++ b/.github/workflows/check-nodejs-dependencies.yml
@@ -60,7 +60,7 @@ jobs:
           cache: 'yarn'
 
       - name: Configure Package Manager
-      # NOTE: Used for npm outdated (run internally in reside-eng/npm-dependency-stats-action)
+        # NOTE: Used for npm outdated (run internally in reside-eng/npm-dependency-stats-action)
         run: |
           echo Configuring NPM_TOKEN globally for .npmrc
           npm config set '//registry.npmjs.org/:_authToken' ${{ secrets.NPM_READ_TOKEN }}


### PR DESCRIPTION
## Changes

<!-- Describe changes made by this PR; consider using bullet points or paragraphs -->
Fixes an issue where the `NODE_VERSION` input is not being respected in the `check-nodejs-dependencies.yml` workflow.
