### PR TITLE
ci: add Claude Code and PR code review workflows

### DIFF
--- a/.github/workflows/claude-code.yml
+++ b/.github/workflows/claude-code.yml
@@ -1,0 +1,25 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+  issues:
+    types: [opened, assigned]
+  pull_request_review:
+    types: [submitted]
+
+permissions:
+  actions: write
+  contents: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  claude:
+    uses: reside-eng/workflow-templates/.github/workflows/claude-code.yml@v12
+    secrets: inherit

--- a/.github/workflows/code-review.yml
+++ b/.github/workflows/code-review.yml
@@ -1,0 +1,21 @@
+name: PR code Review
+
+on:
+  pull_request:
+    types: [opened, ready_for_review, reopened]
+  issue_comment:
+    types: [created]
+
+permissions:
+  actions: write
+  contents: write
+  deployments: write
+  id-token: write
+  issues: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  code-review:
+    uses: reside-eng/workflow-templates/.github/workflows/code-review.yml@v12
+    secrets: inherit


### PR DESCRIPTION
## What

Adds the two standard caller workflows, wired up the same way as our services/UIs/libraries:

- `claude-code.yml` — `@claude` mention handler (issues, PRs, review comments, reviews)
- `code-review.yml` — automated AI PR review on open/ready/reopen and on `@claude /review`

Both delegate to the shared reusable workflows in `reside-eng/workflow-templates@v12` via `secrets: inherit`.

## Activation prerequisites

The reusable workflows are gated on repo/org Actions **variables** and rely on org-level **secrets** (identical to existing consumers). They are inert until enabled:

- **Variables:** `CLAUDE_CODE_ASSISTANT=true` (mention handler), `CLAUDE_CODE_REVIEW=true` (PR review); optionally `USE_CLAUDE_CODE_OAUTH_TOKEN`
- **Secrets (inherited):** `CLAUDE_CODE_API_KEY` / `CLAUDE_CODE_OAUTH_TOKEN`, `JIRA_API_TOKEN`, `JIRA_USER_EMAIL`, `CLAUDE_CODE_SETTINGS`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
